### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Slack Notify - GitHub Action
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,43 @@
 #!/usr/bin/env bash
 
-# Validate subscription status
-API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+REPO_PRIVATE=$(jq -r '.repository.private | tostring' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+UPSTREAM="rtCamp/action-slack-notify"
+ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-# Set a timeout for the curl command (3 seconds)
-RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-CURL_EXIT_CODE=${?}
+echo ""
+echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+echo "Secure drop-in replacement for $UPSTREAM"
+if [ "$REPO_PRIVATE" = "false" ]; then
+  echo -e "\033[32m✓ Free for public repositories\033[0m"
+fi
+echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+echo ""
 
-if [ $CURL_EXIT_CODE -ne 0 ]; then
-  echo "Timeout or API not reachable. Continuing to next step."
-elif [ "$RESPONSE" = "200" ]; then
-  :
-elif [ "$RESPONSE" = "403" ]; then
-  echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-  exit 1
-else
-  echo "Timeout or API not reachable. Continuing to next step."
+if [ "$REPO_PRIVATE" != "false" ]; then
+  SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+  if [ "$SERVER_URL" != "https://github.com" ]; then
+    BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+  else
+    BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+  fi
+
+  API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+  RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$BODY" \
+    "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+  if [ $CURL_EXIT_CODE -ne 0 ]; then
+    echo "Timeout or API not reachable. Continuing to next step."
+  elif [ "$RESPONSE" = "403" ]; then
+    echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+    echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+    exit 1
+  fi
 fi
 
 # Check required env variables


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Docker action: replaced entrypoint.sh subscription block with new format that skips public repos and posts action + ghes_server metadata for private repos

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z